### PR TITLE
feat: sort-nav-list-by-date

### DIFF
--- a/src/hooks/use-all-changelog.js
+++ b/src/hooks/use-all-changelog.js
@@ -6,7 +6,7 @@ const useAllChangelog = () => {
   } = useStaticQuery(graphql`
     query {
       allChangelog(
-        sort: { fields: index, order: DESC }
+        sort: { fields: frontmatter___date, order: DESC }
         filter: { frontmatter: { version: { ne: null } } }
       ) {
         nodes {


### PR DESCRIPTION
## Card
We'd like to show the latest version of Gatsby at the top of the list. 

## Conversation
The nav list on the left of the site is sorted by `index`, this means `v4.9.0` appears before `v4.10.0` or `v4.11.0` in the list.

## Confirmation
Change GraphQL query in `use-all-changelog.js` to sort by `frontmatter___date`